### PR TITLE
Update to v0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,112 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# IDE settings
+.vscode/
+.idea/
+
+# XLSX files
+*.xlsx
+.~lock*#
+
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,16 @@
+Apache Software License 2.0
+
+Copyright (c) 2022, Peter Kruczkiewicz
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 NIM=nim
-PROG=fasta2lmdb
+PROG=release
 
 all:$(PROG)
 
-fasta2lmdb:fasta2lmdb.nim ./lib/klib.nim
-	$(NIM) c -d:release --mm:orc --threads:on -d:nimEmulateOverflowChecks --bound_checks:off -p:./lib -o:$@ $<
+release:fasta2lmdb.nim
+	$(NIM) c -d:release --mm:orc --define:useRealtimeGC --threads:on -d:nimEmulateOverflowChecks --bound_checks:off -p:./lib fasta2lmdb
+
+dev:fasta2lmdb.nim
+	$(NIM) c -u:release --opt:none --mm:orc --threads:on -d:nimEmulateOverflowChecks --bound_checks:off -p:./lib fasta2lmdb
+
+clean:
+	rm fasta2lmdb

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # fasta2lmdb
 
-Quickly save FASTA sequences to an LMDB key-value database for rapid retrieval.
+Quickly save FASTA sequences to an LMDB key-value database for extremely rapid retrieval (get 100k SARS-CoV-2 sequences from a `fasta2lmdb` DB in less than 5 seconds!). Compress sequences with [Zstd] for a DB less than twice as large as a `.tar.xz` (if you train a Zstd dictionary on your sequences)!
 
 ## Rationale
 
 [GISAID] provides an [LZMA] compressed FASTA of SARS-CoV-2 sequences download (e.g. `sequences_fasta_2022_03_23.tar.xz`), which although is very small compared to the uncompressed size of the FASTA (3GB for `tar.xz` vs over 250GB for uncompressed FASTA), this `tar.xz` file can be very slow to retrieve sequences of interest especially if different subsets of the GISAID sequences need to be retrieved.
 
 To address this sequence retrieval bottleneck, `fasta2lmdb` was developed in the [Nim] language to generate an [LMDB] key-value database from a FASTA file using [klib.nim](https://github.com/lh3/biofast/blob/master/lib/klib.nim) from [lh3/biofast](https://github.com/lh3/biofast) for ultrafast FASTA parsing. Keys are FASTA sequence record names and values are the [Zstd] compressed nucleotide sequences.
-
 
 ## Install
 
@@ -20,39 +19,137 @@ make
 
 ## Usage
 
+You can either create an LMDB DB from FASTA sequences piped into `fasta2lmdb` or you can retrieve FASTA sequences from an LMDB with sequence IDs from a text file (one sequence ID per line).
+
+
 Sequences must be piped into `fasta2lmdb` as stdin, e.g.
 
 ```bash
 $ xzcat sequences.fasta.xz | ./fasta2lmdb --dbpath /path/to/seqs_lmdb
 ```
 
-### Recommended Usage with GISAID sequences_fasta_YYYY_mm_dd.tar.xz
-
-Given a `sequences_fasta_YYYY_mm_dd.tar.xz` file from GISAID containing SARS-CoV-2 sequences, decompress the `tar.xz` file with [pixz] for rapid multithreaded decompression, piping stdout into `tar` to extract `sequences.fasta` and, optionally, piping into [pv] to watch progress/bandwidth, and finally piping into `fasta2lmdb` to write the sequences to an [LMDB] at `./gisaidlmdb`:
+GISAID SARS-CoV-2 `sequences_fasta_YYYY_mm_dd.tar.xz` into an LMDB DB
 
 ```bash
 $ pixz -d < /path/to/sequences_fasta_2022_03_17.tar.xz | tar -xOf - sequences.fasta | pv -cN pixztar | ./fasta2lmdb --dbpath ./gisaidlmdb
 ```
 
+Retrieve sequences from LMDB
+
+```bash
+$ ./fasta2lmdb --dbpath /path/to/gisaidlmdb --seqids seqids.txt > seqs.fasta
+```
+
+- **NOTE:** if the sequences are compressed with a Zstd dictionary, the dictionary will be retrieved from the LMDB `info` DB and used to decompress the sequences. Compression with a Zstd dictionary is *highly* recommended since it cuts the LMDB size drastically (e.g. 26 GB to 5.4 GB for the GISAID SARS-CoV-2 sequences from 2022-03-17).
+
+### Recommended Usage with GISAID sequences_fasta_YYYY_mm_dd.tar.xz
+
+It is highly recommended that you train a Zstd dictionary on your input sequences before creating an LMDB with `fasta2lmdb`. You can use the `train_zstd_dictionary_fasta_seqs.py` script to train a dictionary: 
+
+```bash
+$ pixz -d < /path/to/gisaid/sequences_fasta_2022_03_17.tar.xz | tar -xOf - sequences.fasta | python train_zstd_dictionary_fasta_seqs.py --n-seqs 1000
+```
+
+You should see the following terminal output and a `zstd_dictionary` file should be created:
+
+```
+[2022-04-14 15:15:26] INFO     Reading 1000 FASTA sequences from stdin and saving 
+                               to "/tmp/train_zstd_dictionary_fasta_seqs.pyrfwkcaxq"
+                               for Zstd dictionary training.
+[2022-04-14 15:15:27] INFO     Running Zstd training with command: $ ['zstd', '--train', '--maxdict', '112640', '-o', 
+                               'zstd_dictionary', '-r', '/tmp/train_zstd_dictionary_fasta_seqs.pyrfwkcaxq']
+Trying 5 different sets of parameters
+k=1998
+d=8
+f=20
+steps=4
+split=75
+accel=1
+Save dictionary of size 112640 into file /path/to/zstd_dictionary
+                      INFO     Done! Zstd dictionary at "zstd_dictionary"
+```
+
+
+Given a `sequences_fasta_YYYY_mm_dd.tar.xz` file from GISAID containing SARS-CoV-2 sequences, decompress the `tar.xz` file with [pixz] for rapid multithreaded decompression, piping stdout into `tar` to extract `sequences.fasta` and, optionally, piping into [pv] to watch progress/bandwidth, and finally piping into `fasta2lmdb` to write the sequences to an [LMDB] at `./gisaidlmdb`:
+
+```bash
+$ pixz -d < /path/to/sequences_fasta_2022_02_10.tar.xz | tar -xOf - sequences.fasta | pv -cN pixztar | ./fasta2lmdb --dbpath ./gisaidlmdb --zstddict zstd_dictionary
+```
+
 The following messages should appear in the terminal with progress tracked by `pv`:
 ```
-Creating DB at './gisaidlmdb'. Removing 'lock.mdb' and 'data.mdb' if present.
-map size set = 10995116277760
-  pixztar: 4.10GiB 0:00:26 [ 157MiB/s] 
+[15:02:53] - INFO: Creating DB at '/path/to/gisaidlmdb'. Removing 'lock.mdb' and 'data.mdb' if present.
+[15:02:54] - INFO: map size set = 10737418240
+[15:02:54] - INFO: Initialized DBs
+[15:02:54] - INFO: No dict read from DB. zstdDict=zstd_dictionary
+[15:02:54] - INFO: Saved zstd dictionary from 'zstd_dictionary' to LMDB
+[15:02:54] - INFO: Reading records from stdin and saving to LMDB '/path/to/gisaidlmdb'
+     seqs:  223GiB 0:05:55 [ 644MiB/s] [                                                                  <=>          ]
+[15:08:49] - INFO: Read 8050840 records!
+[15:08:49] - INFO: DONE!
 ```
+
+Add new sequences to an existing LMDB with
+
+```bash
+$ pixz -d < /path/to/sequences_fasta_2022_04_14.tar.xz | tar -xOf - sequences.fasta | pv -cN pixztar | ./fasta2lmdb --dbpath ./gisaidlmdb
+```
+
+- **NOTE:** Only new sequences with sequence IDs that do not exist in the DB will be added so this should be faster than creating a new DB. 
+
+### ZStandard Dictionary for better compression!
+
+It's highly recommended that a [ZStandard dictionary](https://facebook.github.io/zstd/) be generated from a sampling of the sequences you wish to put into the LMDB for greater compression.
+
+For all SARS-CoV-2 sequences downloaded on 2022-03-17 from GISAID (as a `tar.xz` file 3.1 GB in size), the uncompressed size was 261GB compared to 26 GB compressed in an LMDB without a dictionary versus 5.4 GB in an LMDB with a dictionary built from a sampling of 10,000 sequences.
+
+- **LMDB of Zstd dictionary compressed sequences was only around 1.7X bigger than the sequences compressed with XZ!**
+
+#### LMDB with ZStandard Dictionary from GISAID SARS-CoV-2
+
+
+
+```bash
+$ pixz -d < sequences_fasta_2022_03_17.tar.xz \
+  | tar -xOf - sequences.fasta \
+  | pv -cN pixztar \
+  | ./fasta2lmdb --dbpath /path/to/gisaid-lmdb --zstdDict gisaid-zstd-dictionary
+```
+
+```
+[08:50:44] - INFO: Creating DB at '/path/to/gisaid-lmdb'. Removing 'lock.mdb' and 'data.mdb' if present.
+[08:50:44] - INFO: map size set = 10995116277760
+[08:50:44] - INFO: Initialized DBs
+[08:50:44] - INFO: Saved zstd dictionary from 'gisaid-zstd-dictionary' to LMDB
+[08:50:44] - INFO: Reading records from stdin and saving to LMDB '/path/to/gisaid-lmdb'
+  pixztar:  261GiB 0:06:37 [ 672MiB/s] [<=>       ]
+[08:57:22] - INFO: DONE!
+```
+
+Very reasonable size for a DB - only 5.4 GB vs 3.1 for `sequences_fasta_2022_03_17.tar.xz`:
+
+```
+$ tree -h
+[4.0K]  .
+├── [5.4G]  data.mdb
+└── [8.0K]  lock.mdb
+```
+
 
 ## Performance
 
-Throughput for extracting `sequences_fasta_2022_03_23.tar.xz` and piping to `/dev/null` was around 450MiB/s:
+> Benchmarking and performance testing was done on laptop with dual M.2 SSD drives in RAID-0. Performance might be better or worse depending on your setup.
+
+Throughput for extracting `sequences_fasta_2022_03_23.tar.xz` and piping to `/dev/null` was around 2.2GiB/s:
 
 ```bash
 $ pixz -d < /path/to/sequences_fasta_2022_03_17.tar.xz | tar -xOf - sequences.fasta | pv -cN pixztar > /dev/null
-  pixztar: 2.58GiB 0:00:06 [ 458MiB/s] [         <=>    ]
+  pixztar: 41.1GiB 0:00:19 [2.18GiB/s]
 ```
 
-`fasta2lmdb` can parse and save compressed sequences to an LMDB DB at around 1/3 (150-160MiB/s) the throughput of writing to `/dev/null`!
+`fasta2lmdb` can parse and save compressed sequences to an LMDB DB at around 1/3 (680-730MiB/s) the throughput of writing to `/dev/null`!
 
-FASTA parsing with Python with [BioPython]'s [SimpleFastaParser]() and *not* compressing or saving sequences to an LMDB was clocked at around 60-65MiB/s.
+FASTA parsing with Python with [BioPython]'s [SimpleFastaParser]() and *not* compressing or saving sequences to an LMDB was clocked at around 350-400MiB/s.
 
 ```python
 #!/usr/bin/env python
@@ -81,7 +178,115 @@ if __name__ == '__main__':
 
 Using [klib kseq.h](https://github.com/attractivechaos/klib/blob/master/kseq.h) with Python could result in better performance, but efficient multithreaded writes to the LMDB would still be an issue with Python unless maybe using Cython.
 
+## Retrieving sequences from the LMDB DB with Python
 
+Requires:
+
+- [lmdb]
+- [zstandard]
+
+Install dependencies with `pip`
+
+```bash
+pip install zstandard lmdb
+
+```
+
+Example Python script to 
+
+```python
+#!/usr/bin/env python
+from typing import Dict, List
+import zstandard
+import lmdb
+from time import time
+import random
+
+
+# Open read-only connection to LMDB DB
+env = lmdb.open('/path/to/lmdb_dir', readonly=True)
+
+# Check number of entries
+with env.begin() as txn:
+    length = txn.stat()['entries']
+    print('DB entries:', length)
+#=> DB entries: 9388892
+
+# Get all keys from DB (not recommended; in reality, you'd be interested in a 
+# specific set of sequences, e.g. sequences based on queries of the GISAID 
+# metadata table (e.g. get all Canadian sequences))
+# NOTE: keys fetched from DB will be bytes (b'Canada/strain123/2022') 
+#       rather than string ('Canada/strain123/2022'). String keys need to be
+#       encoded to bytes (e.g. 'abc'.encode() => b'abc')
+t0 = time()
+db_keys: List[bytes] = []
+with env.begin() as txn:
+    with txn.cursor() as curs:
+        for k in curs.iternext(keys=True, values=False):
+            db_keys.append(k)
+print('fetched', len(db_keys), 'keys in', time() - t0, 'sec')
+#=> fetched 9388892 keys in 83.55254173278809 sec
+
+# Try getting 1,000 sequences from the DB
+# Get random indexesparallel(delayed(txn.get)(seqid) for seqid in seqids)
+idxs: List[int] = list(range(len(db_keys)))
+random.shuffle(idxs)
+N = 1000
+idxs = idxs[:N]
+
+# Put sequences into dict (in reality you'd probably be writing 
+# straight to a file instead or processing them one at a time)
+# NOTE: It might be faster to parallelize the following with multiprocessing or
+#       multithreading since LMDB reads scale linearly with CPU threads, but
+#       CPython threading is notoriously slow and forking processes can be 
+#       expensive.
+t0 = time()
+header_seq: Dict[str, str] = {}
+with env.begin() as txn:
+    for idx in idxs:
+        seqid = db_keys[idx]
+        # if key is string, need to encode to bytes
+        #  seqid = seqid.encode()
+        # NOTE: values fetched from DB will be bytes so it may be necessary to 
+        # decode to string to use without issues
+        header_seq[seqid.decode()] = zstandard.decompress(txn.get(seqid)).decode()
+print('time taken (sec):', time() - t0)
+#=> time taken (sec): 1.5
+print(len(header_seq))
+#=> 1000
+print('sum of seq lens:', sum(len(v) for v in header_seq.values()))
+#=> sum of seq lens: 133742069
+print(seqid)
+#=> <trimmed GISAID virus name>
+print(header_seq[seqid])
+#=> ATCG....
+```
+
+## Known issues
+
+- memory usage increases as more key-value pairs are added to the LMDB. Currently, LMDB Env is closed and reopened to try to limit memory usage by freeing up. An equivalent Rust solution has the same issues. Maybe the LMDB code is aggressively caching keys and/or values? 
+
+## Changelog
+
+### 0.2.0 [2022-04-14]
+
+Added
+
+- Optional but highly recommended Zstd compression with a Zstd trained dictionary on sample input for better compression and faster compression/decompression.
+- `info` DB added to output LMDB containing Zstd dictionary if provided and other metadata about LMDB creation.
+- Add new sequences to an existing LMDB and use Zstd dictionary in LMDB if present (`$ pixz new_seqs | ./fasta2lmdb --dbpath /path/to/existing_lmdb`)
+- `train_zstd_dictionary_fasta_seqs.py` to help train Zstd dictionary for better compression of sequences for `fasta2lmdb`
+- output sequences from `fasta2lmdb` generated LMDB with a file containing sequence IDs using `fasta2lmdb` (`$ ./fasta2lmdb --dbpath /path/to/seqslmdb --seqids seqids.txt > seqs.fasta`)
+
+
+### 0.1.0 [2022-03-22]
+
+Initial alpha release.
+
+
+[lmdb]: https://github.com/jnwatson/py-lmdb/
+[zstandard]: https://github.com/indygreg/python-zstandard
+[BioPython]: https://biopython.org/
 [Nim]: https://nim-lang.org/
 [LZMA]: https://tukaani.org/xz/
 [pixz]: https://github.com/vasi/pixz

--- a/fasta2lmdb.nim
+++ b/fasta2lmdb.nim
@@ -1,62 +1,248 @@
 import std/[os, threadpool, strformat]
 import strutils
 import terminal
+import logging
 
 import bytesequtils
 import cligen
 import zstd/compress
+import zstd/decompress
 import lmdb
 # import from lib/klib.nim; must compile with -p:./lib
 import klib
+
+let VERSION = "0.2.0"
+let INFO_DB_NAME = "info"
+let logger = newConsoleLogger(fmtStr="[$time] - $levelname: ", useStderr=true)
+
 
 proc flush_database_dir(dbname: string) =
   createDir dbname
   discard tryRemoveFile dbname & "/lock.mdb"
   discard tryRemoveFile dbname & "/data.mdb"
 
-proc saveSeq(dbenv: LMDBEnv, name: string, comment: string, sequence: string) = 
+proc compressSeq(
+    sequence: string,
+    dict: string,
+    doCompress: bool = true,
+    level: int = 3): string =
+  var s: string
+  if doCompress:
+    var cctx = new_compress_context()
+    var compressedSeq: seq[byte]
+    if dict != "":
+      compressedSeq = compress(cctx, sequence, dict=dict, level=level)
+    else:
+      compressedSeq = compress(cctx, sequence, level=level)
+    discard free_context(cctx)
+    s = toStrBuf(compressedSeq)
+  else:
+    s = sequence
+  return s
+
+proc getHeader(name: string, comment: string): string =
   var header = name & " " & comment
   header = header.split('|', maxsplit=1)[0]
   header = header.replace(' ', '_')
   header = header.replace("hCoV-19/", "")
-  var compressedSeq = compress(sequence, level=1)
-  let txn = dbenv.newTxn()
-  let dbi = txn.dbiOpen("", 0)
-  var s = toStrBuf(compressedSeq)
+  return header
+
+proc putSeq(dbenv: LMDBEnv, header: string, s: string) =
+  var txn = dbenv.newTxn()
+  var dbi = txn.dbiOpen("", 0)
   try:
     txn.put(dbi, header, s)
     txn.commit()
   except Exception as ex:
-    echo fmt"WTF! header={header} seqlen={len(sequence)}"
-    echo "Error: ", ex.msg, "(", ex.name, ")"
     txn.abort()
     raise ex
   finally:
     dbenv.close(dbi)
 
-proc fasta2lmdb(dbpath="./gisaidseqs", mapSize: uint=10485760 * 1024 * 1024, createDB=true) =
-  ## Read FASTA records from stdin into LMDB key-value database
+proc saveSeq(
+    dbenv: LMDBEnv,
+    dict: string,
+    name: string, 
+    comment: string, 
+    sequence: string,
+    compressSeqs: bool = true, 
+    level: int = 3) =
+  var header = getHeader(name, comment)
+  var compressedSeq = compressSeq(dict=dict, sequence=sequence, doCompress=compressSeqs, level=level)
+  putSeq(dbenv, header, compressedSeq)
+
+proc initInfoDB(dbenv: LMDBEnv, compressSeqs: bool = true) =
+  let txn = dbenv.newTxn()
+  let dbi = txn.dbiOpen(INFO_DB_NAME, flags=CREATE)
+  txn.put(dbi, "fasta2lmdb_version", VERSION)
+  txn.put(dbi, "is_compressed", fmt"{compressSeqs}")
+  txn.commit()
+  dbenv.close(dbi)
+
+proc initSeqsDB(dbenv: LMDBEnv) =
+  let txn = dbenv.newTxn()
+  let dbi = txn.dbiOpen("seqs", flags=CREATE)
+  txn.commit()
+  dbenv.close(dbi)
+
+proc initDBs(dbenv: LMDBEnv, compressSeqs: bool = true) =
+  initInfoDB(dbenv, compressSeqs=compressSeqs)
+  initSeqsDB(dbenv)
+
+proc putZstdDict(dbenv: LMDBEnv, dict: string) =
+  let txn = dbenv.newTxn()
+  let dbi = txn.dbiOpen(INFO_DB_NAME, flags=CREATE)
+  try:
+    txn.put(dbi, "zstd_dictionary", dict)
+    txn.commit()
+  except Exception as ex:
+    stderr.writeLine(fmt"Could not write dict to LMDB. Error: {ex.msg} ({ex.name})")
+    txn.abort()
+    raise ex
+  finally:
+    dbenv.close(dbi)
+
+proc getZstdDict(dbenv: LMDBEnv): string =
+  let txn = dbenv.newTxn()
+  let dbi = txn.dbiOpen(INFO_DB_NAME, 0)
+  try:
+    return txn.get(dbi, "zstd_dictionary")
+  except Exception as ex:
+    stderr.writeLine(fmt"Could not write dict to LMDB. Error: {ex.msg} ({ex.name})")
+    raise ex
+  finally:
+    txn.abort()
+    dbenv.close(dbi)
+
+proc getSeq(dbenv: LMDBEnv, seqid: string, dict: string): string =
+  let txn = dbenv.newTxn()
+  let dbi = txn.dbiOpen("", 0)
+  try:
+    var compressedSeq = txn.get(dbi, seqid)
+    var dctx = new_decompress_context()
+    var decompressedSeq: seq[byte]
+    if dict != "":
+      decompressedSeq = decompress(dctx, compressedSeq, dict=dict)
+    else:
+      decompressedSeq = decompress(dctx, compressedSeq)
+    discard free_context(dctx)
+    return toStrBuf(decompressedSeq)
+  except Exception as ex:
+    stderr.writeLine(fmt"Could not get sequence for '{seqid}' from LMDB. Error: {ex.msg}")
+    return ""
+  finally:
+    txn.abort()
+    dbenv.close(dbi)
+
+proc writeFastaSeqToStdout(seqid: string, sequence: string) =
+  stdout.writeLine(fmt">{seqid}")
+  stdout.writeLine(sequence)
+
+proc getLMDBSeqWriteToStdout(dbenv: LMDBEnv, seqid: string, dict: string) =
+  writeFastaSeqToStdout(seqid, getSeq(dbenv, seqid, dict))
+
+proc toLMDB(
+    dbpath: string, 
+    zstdDict: string = "",
+    mapSize: uint = 10485760 * 1024,
+    overwriteDB: bool = false,
+    compressSeqs: bool = true,
+    level: int = 3) =
+  var useExistingDict = false
+  if not overwriteDB and dirExists(dbpath):
+    logger.log(lvlInfo, fmt"Trying to read zstd dictionary from existing LMDB at '{dbpath}'")
+    useExistingDict = true
+  if overwriteDB or not dirExists(dbpath):
+    logger.log(lvlInfo, fmt"Creating DB at '{dbpath}'. Removing 'lock.mdb' and 'data.mdb' if present.")
+    flush_database_dir(dbpath)
+  var dbenv = newLMDBEnv(dbpath, openflags=MAPASYNC or NOSYNC, maxdbs=10)
+  discard envSetMapsize(dbenv, mapSize)
+  logger.log(lvlInfo, fmt"map size set = {mapSize}")
+  var dict: string = ""
+  if useExistingDict:
+    dict = getZstdDict(dbenv)
+  else:
+    initDBs(dbenv, compressSeqs=compressSeqs)
+    logger.log(lvlInfo, "Initialized DBs")
+  
+  var f = xopen[GzFile]("-")
+  defer: f.close()
+  var rec: FastxRecord
+  
+  if dict == "" or not useExistingDict or overwriteDB:
+    logger.log(lvlInfo, fmt"No dict read from DB. zstdDict={zstdDict}")
+    if zstdDict != "" and fileExists(zstdDict):
+      dict = readFile(zstdDict)
+      putZstdDict(dbenv, dict)
+      logger.log(lvlInfo, fmt"Saved zstd dictionary from '{zstdDict}' to LMDB")
+    else:
+      logger.log(lvlInfo, "No zstd dictionary!")
+      dict = ""
+  
+  logger.log(lvlInfo, fmt"Reading records from stdin and saving to LMDB '{dbpath}'")
+  var count = 0
+  var val: string
+  while f.readFastx(rec):
+    if useExistingDict:
+      let txn = dbenv.newTxn()
+      let dbi = txn.dbiOpen("", 0)
+      try:
+        val = txn.get(dbi, getHeader(rec.name, rec.comment))
+      except:
+        spawn saveSeq(dbenv, dict, rec.name, rec.comment, rec.seq, compressSeqs, level)
+      finally:
+        txn.abort()
+        dbenv.close(dbi)
+    else:
+      spawn saveSeq(dbenv, dict, rec.name, rec.comment, rec.seq, compressSeqs, level)
+    
+    count += 1
+    # Memory usage keeps climbing as more values are put into the LMDB.
+    # Keys and values put into the DB seem to be kept in memory through the 
+    # LMDBEnv object. Recreating the LMDBEnv frees up memory and reduces max
+    # memory usage.
+    if count mod 300_000 == 0:
+      threadpool.sync()
+      dbenv.envClose()
+      dbenv = newLMDBEnv(dbpath, openflags=MAPASYNC or NOSYNC, maxdbs=10)
+      discard envSetMapsize(dbenv, mapSize)
+      
+  threadpool.sync()
+  dbenv.envClose()
+  logger.log(lvlInfo, fmt"Read {count} records!")
+  logger.log(lvlInfo, "DONE!")
+
+proc fasta2lmdb(
+    dbpath="./gisaidseqs", 
+    mapSize: uint = 10485760 * 1024, 
+    overwriteDB = false,
+    seqids = "",
+    zstdDict = "",
+    compressSeqs: bool = true) =
+  ## Read FASTA records from stdin into LMDB key-value database or get sequences from LMDB
   ##
-  ## Expected usage:
+  ## Expected usage to create an LMDB DB from a FASTA piped into fasta2lmdb:
   ##
   ## $ pixz -d < sequences_fasta_YYYY_mm_dd.tar.xz | tar -xOf - sequences.fasta | fasta2lmdb --dbpath ./gisaidseqs
   ##
+  ## Expected usage to retrieve sequences from LMDB DB to stdout:
+  ##
+  ## $ fasta2lmdb --dbpath /path/to/gisaidseqs --seqids seqids.txt > seqs.fasta
+  ##
+  ## where "seqids.txt" contains sequence IDs to retrieve; one per line
   if not isatty(stdin):
-    if createDB:
-      echo "Creating DB at '", dbpath, "'. Removing 'lock.mdb' and 'data.mdb' if present."
-      flush_database_dir(dbpath)
-    let dbenv = newLMDBEnv(dbpath, openflags=MAPASYNC or NOSYNC)
-    discard envSetMapsize(dbenv, mapSize)
-    echo "map size set = ", mapSize
-    var f = xopen[GzFile]("-")
-    defer: f.close()
-    var rec: FastxRecord
-    while f.readFastx(rec):
-      spawn saveSeq(dbenv, rec.name, rec.comment, rec.seq)
-    threadpool.sync()
-    dbenv.envClose()
-    echo "DONE!"
+    toLMDB(dbpath, zstdDict, mapSize, overwriteDB, compressSeqs)
   else:
-    raise newException(Exception, "No stdin stream present :-(")
+    if not seqids.fileExists():
+      raise newException(Exception, fmt"No stdin stream present and file with sequence IDs ('{seqids}') does not exist!")
+    logger.log(lvlInfo, fmt"Start fetch sequences from LMDB '{dbpath}' with IDs in '{seqids}'")
+    let dbenv = newLMDBEnv(dbpath, maxdbs=10)
+    let dict = getZstdDict(dbenv)
+    for line in seqids.lines:
+      if line == "":
+        continue
+      getLMDBSeqWriteToStdout(dbenv, line, dict)
+    dbenv.envClose()
+    logger.log(lvlInfo, "DONE!")
 
 dispatch(fasta2lmdb)

--- a/fasta2lmdb.nimble
+++ b/fasta2lmdb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.2.0"
 author        = "Peter Kruczkiewicz"
 description   = "Quickly save FASTA sequences to an LMDB key-value database for rapid retrieval."
 license       = "Apache-2.0"

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,6 +1,6 @@
---mm:orc
 -d:release
 --threads:on
 -d:nimEmulateOverflowChecks
+--define:useRealtimeGC
 --bound_checks:off
 -p:lib

--- a/train_zstd_dictionary_fasta_seqs.py
+++ b/train_zstd_dictionary_fasta_seqs.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+import logging
+import subprocess as sp
+import sys
+import tempfile
+from pathlib import Path
+from typing import Tuple, Iterator, List
+
+import typer
+from rich.console import Console
+from rich.logging import RichHandler
+
+
+def init_logging(verbose: bool) -> None:
+    from rich.traceback import install
+    console = Console(stderr=True)
+    install(show_locals=True, word_wrap=True, console=console)
+    logging.basicConfig(
+        format="%(message)s",
+        datefmt="[%Y-%m-%d %X]",
+        level=logging.DEBUG if verbose else logging.INFO,
+        handlers=[RichHandler(rich_tracebacks=True,
+                              tracebacks_show_locals=True,
+                              locals_max_string=None,
+                              console=console)],
+    )
+
+
+def read_fasta(handle) -> Iterator[Tuple[str, str]]:
+    # Skip any text before the first record (e.g. blank lines, comments)
+    title = ""
+    for line in handle:
+        if line.startswith(">"):
+            title = line[1:].rstrip()
+            break
+        else:
+            # no break encountered - probably an empty file
+            return
+    lines: List[str] = []
+    for line in handle:
+        if line.startswith(">"):
+            yield title, "".join(lines).replace(" ", "").replace("\r", "")
+            lines = []
+            title = line[1:].rstrip()
+            continue
+        lines.append(line.rstrip())
+    yield title, "".join(lines).replace(" ", "").replace("\r", "")
+
+
+def main(
+        zstddict: Path = typer.Option(Path('zstd_dictionary'), '-o', '--zstddict', help='Zstd dictionary output path.'),
+        n_seqs: int = typer.Option(1000, '-n', '--n-seqs', help='Number of sequences to train Zstd dictionary with.'),
+        maxdict: int = typer.Option(112640, help='Limit Zstd dictionary to specified size'),
+        verbose: bool = typer.Option(False, is_flag=True),
+) -> None:
+    """Train Zstd dictionary from FASTA sequences
+
+    Example Usage:
+
+    $ zcat sequences.fasta.gz | ./train_zstd_dictionary_fasta_seqs.py -d zstd_dictionary
+
+    Only the sequences themselves will be used for training the Zstd dictionary.
+    """
+    init_logging(verbose)
+    logging.debug(f'{zstddict=}|{n_seqs=}|{maxdict=}')
+    if sys.stdin.isatty():
+        logging.error(f'FASTA sequences need to be piped into this script via stdin. Example usage: '
+                      f'"$ xzcat sequences.fasta.xz | {Path(__file__).name}"')
+        sys.exit(1)
+
+    with tempfile.TemporaryDirectory(prefix=Path(__file__).name) as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        logging.info(f'Reading {n_seqs} FASTA sequences from stdin and saving to '
+                     f'"{tmpdir}" for Zstd dictionary training.')
+        for i, (_, seq) in enumerate(read_fasta(sys.stdin)):
+            if i >= n_seqs:
+                break
+            seqfile = tmpdir_path / f'{i}'
+            seqfile.write_text(seq)
+        cmd = [
+            'zstd', '--train',
+            '--maxdict', f'{maxdict}',
+            '-o', str(zstddict.resolve().absolute()),
+            '-r', str(tmpdir_path.resolve().absolute())
+        ]
+        logging.info(f'Running Zstd training with command: $ {cmd}')
+        sp.check_call(cmd)
+    logging.info(f'Done! Zstd dictionary at "{zstddict.absolute()}"')
+
+
+if __name__ == '__main__':
+    typer.run(main)


### PR DESCRIPTION
Now with Zstd dictionary compression and ability to get sequences with fasta2lmdb from LMDB

- Optional but highly recommended Zstd compression with a Zstd trained dictionary on sample input for better compression and faster compression/decompression.
- `info` DB added to output LMDB containing Zstd dictionary if provided and other metadata about LMDB creation.
- Add new sequences to an existing LMDB and use Zstd dictionary in LMDB if present (`$ pixz new_seqs | ./fasta2lmdb --dbpath /path/to/existing_lmdb`)
- `train_zstd_dictionary_fasta_seqs.py` to help train Zstd dictionary for better compression of sequences for `fasta2lmdb`
- output sequences from `fasta2lmdb` generated LMDB with a file containing sequence IDs using `fasta2lmdb` (`$ ./fasta2lmdb --dbpath /path/to/seqslmdb --seqids seqids.txt > seqs.fasta`)