### PR TITLE
Fix static compilation and patch version bump to 0.2.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,69 @@
+# adapted from https://github.com/brentp/mosdepth/
+name: Build
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-latest]
+        version:
+          - stable
+          - devel
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Caching
+    - name: Cache choosenim
+      id: cache-choosenim
+      uses: actions/cache@v3
+      with:
+        path: ~/.choosenim
+        key: ${{ runner.os }}-choosenim-stable
+
+    - name: Cache nimble
+      id: cache-nimble
+      uses: actions/cache@v3
+      with:
+        path: ~/.nimble
+        key: ${{ runner.os }}-nimble-stable
+
+    - name: Cache LMDB
+      id: cache-lmdb
+      uses: actions/cache@v3
+      with:
+        path: $HOME/lmdb
+        key: ${{ runner.os }}-lmdb
+
+    # Install Dependencies
+    - name: Install dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get -qy install make build-essential curl libtool autoconf zlib1g-dev liblmdb-dev
+
+    # Install Nim and Nimble
+    - uses: iffy/install-nim@v4.1.1
+      with:
+        version: ${{ matrix.version }}
+
+    # Build
+    - name: Build executable
+      run: |
+        nimble build --verbose
+        ./fasta2lmdb -h
+
+    - name: "Build and Copy release binary"
+      run: nim c -d:release -o:bin/fasta2lmdb_${{ matrix.os }} fasta2lmdb
+
+    - name: Upload Artifact
+      if: success()
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: fasta2lmdb_${{ matrix.os }}
+        path: bin/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
     # Build
     - name: Build executable
       run: |
-        nimble build --verbose
+        nimble build --verbose -Y
         ./fasta2lmdb -h
 
     - name: "Build and Copy release binary"

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,7 @@ ENV/
 .~lock*#
 
 
+nimbledeps/
+zstd_dictionary
+sars-cov-2-zstd-dictionary
+fasta2lmdb

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # fasta2lmdb
 
+[![Build](https://github.com/peterk87/fasta2lmdb/actions/workflows/build.yml/badge.svg)](https://github.com/peterk87/fasta2lmdb/actions/workflows/build.yml)
+
 Quickly save FASTA sequences to an LMDB key-value database for extremely rapid retrieval (get 100k SARS-CoV-2 sequences from a `fasta2lmdb` DB in less than 5 seconds!). Compress sequences with [Zstd] for a DB less than twice as large as a `.tar.xz` (if you train a Zstd dictionary on your sequences)!
 
 ## Rationale

--- a/fasta2lmdb.nimble
+++ b/fasta2lmdb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "Peter Kruczkiewicz"
 description   = "Quickly save FASTA sequences to an LMDB key-value database for rapid retrieval."
 license       = "Apache-2.0"

--- a/nim.cfg
+++ b/nim.cfg
@@ -3,4 +3,26 @@
 -d:nimEmulateOverflowChecks
 --define:useRealtimeGC
 --bound_checks:off
--p:lib
+-p:"lib"
+mm:orc
+
+# nim c -a -d:static fasta2lmdb.nim
+@if static:
+  passL = "-static"
+  passC = "-static"
+  # musl-gcc produces a binary that is much slower than regular gcc for some reason
+  # gcc.exe = "musl-gcc"
+  # gcc.linkerexe = "musl-gcc"
+  
+  passL:"/usr/lib/libz.a"
+  dynlibOverride:"z"
+  # download and build the latest version of LMDB. For example,
+  # $ curl -SLk https://github.com/LMDB/lmdb/archive/refs/tags/LMDB_0.9.29.tar.gz | tar -xzf -
+  # $ cd lmdb-LMDB_0.9.29/libraries/liblmdb/
+  # $ make
+  # $ sudo make install
+  passL:"/usr/local/lib/liblmdb.a"
+  dynlibOverride:"lmdb"
+  passL:"-lpthread"
+  dynlibOverride:"pthread"
+@end


### PR DESCRIPTION
- fix issue when sequences being fetched from LMDB with no Zstd dictionary
- klib.nim: use system libc memchr from string.h header
- klib.nim: remove unused functions
- nim.cfg: add static compile definition flag (-d:static)
- update README.md to include instructions for static compilation
- add GitHub Actions build.yml workflow